### PR TITLE
Remove bus.cpp from the specs

### DIFF
--- a/specs/hw14.yaml
+++ b/specs/hw14.yaml
@@ -7,7 +7,6 @@ compilers:
   - &cpp 'g++-4.9 --std=c++11 $@ -o $@.exec'
 
 files:
-  - [ bus.cpp, *cpp ]
   - [ bus1.cpp, *cpp ]
   - [ bus2.cpp, *cpp ]
   - [ bus3.cpp, *cpp ]
@@ -16,7 +15,6 @@ files:
   - [ copyn.cpp, *cpp ]
 
 tests:
-  - [ bus.cpp, $@.exec ]
   - [ bus1.cpp, $@.exec ]
   - [ bus2.cpp, $@.exec ]
   - [ bus3.cpp, $@.exec ]


### PR DESCRIPTION
Current files on [the wiki page](https://www.cs.stolaf.edu/wiki/index.php/Homework_14_(SD_S18_A)) are:

`bus1.cpp bus2.cpp bus3.cpp class1.cpp class2.cpp copyn.cpp`

This PR updates those to reflect those changes.